### PR TITLE
checkpoint: ecr repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Local .terraform directories
 **/.terraform/*
 
+generated/*
+
 # .tfstate files
 *.tfstate
 *.tfstate.*

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -61,6 +61,25 @@ provider "registry.terraform.io/hashicorp/kubernetes" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.5.3"
+  hashes = [
+    "h1:MCzg+hs1/ZQ32u56VzJMWP9ONRQPAAqAjuHuzbyshvI=",
+    "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
+    "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
+    "zh:6243509bb208656eb9dc17d3c525c89acdd27f08def427a0dce22d5db90a4c8b",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:885d85869f927853b6fe330e235cd03c337ac3b933b0d9ae827ec32fa1fdcdbf",
+    "zh:bab66af51039bdfcccf85b25fe562cbba2f54f6b3812202f4873ade834ec201d",
+    "zh:c505ff1bf9442a889ac7dca3ac05a8ee6f852e0118dd9a61796a2f6ff4837f09",
+    "zh:d36c0b5770841ddb6eaf0499ba3de48e5d4fc99f4829b6ab66b0fab59b1aaf4f",
+    "zh:ddb6a407c7f3ec63efb4dad5f948b54f7f4434ee1a2607a49680d494b1776fe1",
+    "zh:e0dafdd4500bec23d3ff221e3a9b60621c5273e5df867bc59ef6b7e41f5c91f6",
+    "zh:ece8742fd2882a8fc9d6efd20e2590010d43db386b920b2a9c220cfecc18de47",
+    "zh:f4c6b3eb8f39105004cf720e202f04f57e3578441cfb76ca27611139bc116a82",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/tls" {
   version = "4.0.6"
   hashes = [

--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ This projects contains Terraform code to create a fully functional Amazon EKS (E
 - OIDC integration for service accounts
 - Private endpoint access enabled
 
+## Windows API Instance Access
+- Terraform instala y habilita OpenSSH Server en la instancia Windows durante el aprovisionamiento.
+- La clave privada generada se almacena en `generated/windows-api-key.pem`.
+- Acceso SSH de ejemplo: `ssh -i generated/windows-api-key.pem Administrator@<windows-api-public-ip>`.
+- Puedes inyectar claves públicas adicionales usando la variable `module "ec2" -> additional_ssh_public_keys` (útil para GitHub Actions u otros automatismos).
+- Restringe el puerto 22 en el security group `eks-terraform-windows-api-sg` para mayor seguridad o considera Session Manager si prefieres evitar exponer SSH.
+
 ## Tagging Strategy
 All resources are tagged with:
 - Project name

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Terraform EKS Cluster
 
-This projects contains Terraform code to create a fully functional Amazon EKS (Elastic Kubernetes Service) cluster with all the necessary networking infrastructure on AWS.
+This projects contains Terraform code to create a fully functional Amazon EKS (Elastic Kubernetes Service) cluster with all the necessary networking infrastructure on AWS, plus supporting components for container registries, Windows interoperability, and ingress management.
 
 ## Infrastructure Overview
 
@@ -15,6 +15,12 @@ This projects contains Terraform code to create a fully functional Amazon EKS (E
   - Public route table: Routes traffic through Internet Gateway
   - Private route table: Routes traffic through NAT Gateway
 
+### Container Registry (ECR)
+- Provisiona dos repositorios ECR dedicados:
+  - `frontend-dashboard`
+  - `backend-ventas`
+- Habilita cifrado en repositorio (AES256) y expone las URLs via outputs de Terraform para integraciones CI/CD.
+
 ### EKS Cluster
 - Create an EKS Cluster version 1.32
 - Deploys the cluster control plane in the private subnets
@@ -24,10 +30,11 @@ This projects contains Terraform code to create a fully functional Amazon EKS (E
 
 ### Node Group
 - Creates a managed node group with:
-  - ARM-based instances (t4g.medium)
+  - x86_64-based instances (t3.medium)
   - Auto-scaling configuration (min: 2, desired: 2, max: 3 nodes)
   - 20GB disk size per node
   - Deployed in private subnets
+- Etiqueta `kubernetes.io/arch=amd64` para distinguir workloads y compatibilidad con ingress basado en NGINX.
 - Configures requried IAM roles and policies for nodes including:
   - EKS worker node policy
   - CNI policy
@@ -40,7 +47,14 @@ This projects contains Terraform code to create a fully functional Amazon EKS (E
 - Installs Nginx Ingress Controller using Helm
 - Sets up IAM roles and policies for the Load Balancer Controller
 - Configures OIDC-based authentication for service accounts
-- Configures ALB Ingress for Nginx Controller access
+- Configures ALB Ingress for Nginx Controller access y publica un `Ingress` adicional para exponer el controlador por medio de un Application Load Balancer con esquema internet-facing.
+- Despliega un `IngressClass` basado en ALB y habilita reutilización de grupo (`alb.ingress.kubernetes.io/group.name`).
+
+### Windows API Bridge
+- Crea una instancia Windows Server con OpenSSH configurado y puerto 5085 expuesto dentro del VPC CIDR.
+- Genera automáticamente un nuevo par de llaves (`generated/windows-api-key.pem`) y permite añadir claves adicionales.
+- Publica un `Service`, `Endpoints` y `Ingress` en Kubernetes que enrutan `/api/inventario/` hacia la instancia Windows a través del NGINX Ingress Controller.
+- Permite personalizar anotaciones, `IngressClass` y direcciones IP de backend con variables del módulo.
 
 ## Module Structure
 - `vpc`: Handles VPC creation and basic networking
@@ -48,17 +62,22 @@ This projects contains Terraform code to create a fully functional Amazon EKS (E
 - `gateways`: Configures Internet Gateway, NAT Gateway and Route Tables
 - `eks`: Manaes the EKS cluster and its IAM roles
 - `eks-node-group`: Handles the EKS worker nodes configuration
-- `eks-add-ons`: Manages cluster add-ons and their IAM configurations
+- `eks-addons`: Manages cluster add-ons (AWS Load Balancer Controller, nginx-ingress) and their IAM configurations
+- `ecr`: Provisiona repositorios ECR para front y back
+- `ec2`: Administra la instancia Windows API, security groups y claves
+- `k8s-windows-api`: Publica la capa de networking en Kubernetes contra la instancia Windows
 
 ## Ingress Architecture
 - AWS Application Load Balancer (ALB) as the external entry point
 - Nginx Ingress Controller running with ClusterIP service type
 - Two-tier ingress setup:
   - ALB Ingress -> Nginx Ingress Controller
-  - Nginx Ingress -> Backend Services
+  - Nginx Ingress -> Backend Services (workloads Linux en Kubernetes)
+  - Nginx Ingress -> Windows API Service (backing EC2 instance)
 - Sample applications provided to test ingress routing:
   - Blue/Green application (/blue and /green paths)
   - Orange/Purple application (/orange and /purple paths)
+- Windows API expuesto vía `/api/inventario/` y balanceado por Nginx.
 
 ## Security Features
 - Private subnets for worker nodes
@@ -68,7 +87,7 @@ This projects contains Terraform code to create a fully functional Amazon EKS (E
 - Private endpoint access enabled
 
 ## Windows API Instance Access
-- Terraform instala y habilita OpenSSH Server en la instancia Windows durante el aprovisionamiento.
+- Terraform instala y habilita OpenSSH Server y reglas de firewall (22, 3389, 5085) en la instancia Windows durante el aprovisionamiento.
 - La clave privada generada se almacena en `generated/windows-api-key.pem`.
 - Acceso SSH de ejemplo: `ssh -i generated/windows-api-key.pem Administrator@<windows-api-public-ip>`.
 - Puedes inyectar claves públicas adicionales usando la variable `module "ec2" -> additional_ssh_public_keys` (útil para GitHub Actions u otros automatismos).
@@ -86,7 +105,7 @@ All resources are tagged with:
 
 ## Importante Notes
 - ***This is a test project to learn how to create a EKS cluster using Terraform, it is not intended to be used as a production cluster***
-- The cluster uses ARM-based instances for cost optimization
+- The cluster uses x86_64 instances optimizadas para compatibilidad amplia con workloads y controladores
 - NAT Gateway is deployed in the first public subnet.
 - Load Balancer Controller is installed for mananing AWS ALB/NLB.
 - Nginx Ingress Controller is deployed with ClusterIP service type.

--- a/apps/README.md
+++ b/apps/README.md
@@ -1,10 +1,10 @@
 ## What's here?
-This folder contains dummy apps to deploy to the EKS cluster and validate if the nginx ingress controller is working as expected with the ALB.
+This folder contains dummy apps to deploy to the EKS cluster and validate if the nginx ingress controller is working as expected with the ALB. Incluye ejemplos Linux (blue/green y orange/purple) y la API Windows publicada vía `/api/inventario/`.
 
 ## How to deploy
 1. Apply each file in the folder using `kubectl apply -f <filename>.yaml`
 2. Validate the deployment by running `kubectl get all --namespace <namespace>`
-3. Try to access the app using the ALB ingress endpoint. For example: `http://<alb-ingress-endpoint>/green/`
+3. Try to access the app using the ALB ingress endpoint. For example: `http://<alb-ingress-endpoint>/green/` o `http://<alb-ingress-endpoint>/api/inventario/`
 
 ### Reference
 - [A deeper look at ingress sharing and target group binding in AWS Load Balancer Controller](https://aws.amazon.com/blogs/containers/a-deeper-look-at-ingress-sharing-and-target-group-binding-in-aws-load-balancer-controller/)

--- a/docs/01-after-creating-eks.md
+++ b/docs/01-after-creating-eks.md
@@ -64,3 +64,11 @@ When connecting from outside AWS CloudShell:
 - Verify your AWS credentials have the necessary permissions to interact with EKS.
 - Check that security groups allow traffic from your location to the cluster.
 - If using private endpoints, ensure you have proper VPN.
+
+## Next steps
+
+- Deploy the sample apps under apps/ to validate the ALB -> NGINX -> Linux workloads flow.
+
+- Confirm that the windows-api-ingress routes correctly to the Windows instance by visiting http://<alb-ingress-endpoint>/api/inventario/.
+
+- Rotate or download the private key generated at generated/windows-api-key.pem if you plan to access the Windows instance via SSH/RDP.

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,9 @@ terraform {
     tls = {
       source = "hashicorp/tls"
     }
+    local = {
+      source = "hashicorp/local"
+    }
   }
 }
 
@@ -119,4 +122,15 @@ module "ecr" {
 
   project_name = local.project_name
   tags         = local.common_tags
+}
+
+module "ec2" {
+  source = "./modules/ec2"
+
+  project_name             = local.project_name
+  vpc_id                   = module.vpc.vpc_id
+  public_subnet_id         = module.subnets.public_subnet_ids[0]
+  tags                     = local.common_tags
+  http_ingress_cidrs       = [module.vpc.vpc_cidr]
+  private_key_output_path  = "${path.root}/generated/windows-api-key.pem"
 }

--- a/main.tf
+++ b/main.tf
@@ -113,3 +113,10 @@ module "eks_addons" {
 
   depends_on = [ module.eks, module.eks_node_group ]
 }
+
+module "ecr" {
+  source = "./modules/ecr"
+
+  project_name = local.project_name
+  tags         = local.common_tags
+}

--- a/main.tf
+++ b/main.tf
@@ -17,13 +17,13 @@ provider "aws" {
 }
 
 provider "kubernetes" {
-  host = module.eks.cluster_endpoint
+  host                   = module.eks.cluster_endpoint
   cluster_ca_certificate = base64decode(module.eks.cluster_ca_certificate)
 
   exec {
     api_version = "client.authentication.k8s.io/v1beta1"
-    command = "aws"
-    args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+    command     = "aws"
+    args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
   }
 }
 
@@ -53,7 +53,7 @@ module "subnets" {
   public_subnet_cidrs  = ["10.0.1.0/24", "10.0.2.0/24"]
   private_subnet_cidrs = ["10.0.3.0/24", "10.0.4.0/24"]
   availability_zones   = ["us-west-2a", "us-west-2b"]
-  
+
   tags = local.common_tags
 }
 
@@ -61,10 +61,10 @@ module "gateways" {
   source = "./modules/gateways"
 
   project_name       = local.project_name
-  vpc_id            = module.vpc.vpc_id
-  public_subnet_ids = module.subnets.public_subnet_ids
+  vpc_id             = module.vpc.vpc_id
+  public_subnet_ids  = module.subnets.public_subnet_ids
   private_subnet_ids = module.subnets.private_subnet_ids
-  tags              = local.common_tags
+  tags               = local.common_tags
 
   depends_on = [module.vpc, module.subnets]
 }
@@ -72,35 +72,35 @@ module "gateways" {
 module "eks" {
   source = "./modules/eks"
 
-  project_name = local.project_name
-  vpc_id = module.vpc.vpc_id
+  project_name       = local.project_name
+  vpc_id             = module.vpc.vpc_id
   private_subnet_ids = module.subnets.private_subnet_ids
-  tags = local.common_tags
+  tags               = local.common_tags
 
-  depends_on = [ module.vpc, module.subnets, module.gateways ]
+  depends_on = [module.vpc, module.subnets, module.gateways]
 }
 
 module "eks_node_group" {
   source = "./modules/eks-node-group"
 
-  project_name = local.project_name
-  cluster_name = module.eks.cluster_name
-  node_role_arn = module.eks.node_role_arn
+  project_name       = local.project_name
+  cluster_name       = module.eks.cluster_name
+  node_role_arn      = module.eks.node_role_arn
   private_subnet_ids = module.subnets.private_subnet_ids
-  tags = local.common_tags
+  tags               = local.common_tags
 
-  cluster_depends_on = [ module.eks ]
+  cluster_depends_on = [module.eks]
 }
 
 provider "helm" {
   kubernetes {
-    host = module.eks.cluster_endpoint
+    host                   = module.eks.cluster_endpoint
     cluster_ca_certificate = base64decode(module.eks.cluster_ca_certificate)
 
     exec {
       api_version = "client.authentication.k8s.io/v1beta1"
-      command = "aws"
-      args = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
+      command     = "aws"
+      args        = ["eks", "get-token", "--cluster-name", module.eks.cluster_name]
     }
   }
 }
@@ -108,13 +108,13 @@ provider "helm" {
 module "eks_addons" {
   source = "./modules/eks-addons"
 
-  project_name = local.project_name
-  cluster_name = module.eks.cluster_name
-  cluster_endpoint = module.eks.cluster_endpoint
+  project_name        = local.project_name
+  cluster_name        = module.eks.cluster_name
+  cluster_endpoint    = module.eks.cluster_endpoint
   cluster_oidc_issuer = module.eks.cluster_oidc_issuer
-  tags = local.common_tags
+  tags                = local.common_tags
 
-  depends_on = [ module.eks, module.eks_node_group ]
+  depends_on = [module.eks, module.eks_node_group]
 }
 
 module "ecr" {
@@ -127,23 +127,24 @@ module "ecr" {
 module "ec2" {
   source = "./modules/ec2"
 
-  project_name             = local.project_name
-  vpc_id                   = module.vpc.vpc_id
-  public_subnet_id         = module.subnets.public_subnet_ids[0]
-  tags                     = local.common_tags
-  http_ingress_cidrs       = [module.vpc.vpc_cidr]
-  private_key_output_path  = "${path.root}/generated/windows-api-key.pem"
+  project_name               = local.project_name
+  vpc_id                     = module.vpc.vpc_id
+  public_subnet_id           = module.subnets.public_subnet_ids[0]
+  tags                       = local.common_tags
+  http_ingress_cidrs         = [module.vpc.vpc_cidr]
+  private_key_output_path    = "${path.root}/generated/windows-api-key.pem"
+  additional_ssh_public_keys = []
 }
 
 module "k8s_windows_api" {
   source = "./modules/k8s-windows-api"
 
-  project_name   = local.project_name
-  endpoint_ips   = [module.ec2.private_ip]
-  namespace      = "default"
-  service_name   = "windows-api-service"
-  ingress_name   = "windows-api-ingress"
-  path           = "/api/inventario/"
+  project_name = local.project_name
+  endpoint_ips = [module.ec2.private_ip]
+  namespace    = "default"
+  service_name = "windows-api-service"
+  ingress_name = "windows-api-ingress"
+  path         = "/api/inventario/"
 
   depends_on = [module.eks_addons]
 }

--- a/main.tf
+++ b/main.tf
@@ -134,3 +134,16 @@ module "ec2" {
   http_ingress_cidrs       = [module.vpc.vpc_cidr]
   private_key_output_path  = "${path.root}/generated/windows-api-key.pem"
 }
+
+module "k8s_windows_api" {
+  source = "./modules/k8s-windows-api"
+
+  project_name   = local.project_name
+  endpoint_ips   = [module.ec2.private_ip]
+  namespace      = "default"
+  service_name   = "windows-api-service"
+  ingress_name   = "windows-api-ingress"
+  path           = "/api/inventario/"
+
+  depends_on = [module.eks_addons]
+}

--- a/main.tf
+++ b/main.tf
@@ -145,6 +145,7 @@ module "k8s_windows_api" {
   service_name = "windows-api-service"
   ingress_name = "windows-api-ingress"
   path         = "/api/inventario/"
+  service_port = 5085
 
   depends_on = [module.eks_addons]
 }

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -55,9 +55,17 @@ resource "aws_security_group" "windows_api" {
   }
 
   ingress {
+    description = "RDP access"
+    from_port   = 3389
+    to_port     = 3389
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
     description = "HTTP access from VPC"
-    from_port   = 80
-    to_port     = 80
+    from_port   = 5085
+    to_port     = 5085
     protocol    = "tcp"
     cidr_blocks = var.http_ingress_cidrs
   }

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -14,6 +14,15 @@ resource "tls_private_key" "windows_api" {
   rsa_bits  = 4096
 }
 
+locals {
+  ssh_public_keys = distinct(concat(
+    [tls_private_key.windows_api.public_key_openssh],
+    var.additional_ssh_public_keys
+  ))
+
+  ssh_authorized_keys = join("\n", local.ssh_public_keys)
+}
+
 resource "local_file" "windows_api_private_key" {
   filename          = var.private_key_output_path
   sensitive_content = tls_private_key.windows_api.private_key_pem
@@ -75,6 +84,11 @@ resource "aws_instance" "windows_api" {
   vpc_security_group_ids      = [aws_security_group.windows_api.id]
   associate_public_ip_address = true
   key_name                    = aws_key_pair.windows_api.key_name
+
+  user_data_replace_on_change = true
+  user_data = templatefile("${path.module}/userdata.ps1.tpl", {
+    authorized_keys = local.ssh_authorized_keys
+  })
 
   tags = merge(
     var.tags,

--- a/modules/ec2/main.tf
+++ b/modules/ec2/main.tf
@@ -1,0 +1,87 @@
+terraform {
+  required_providers {
+    tls = {
+      source = "hashicorp/tls"
+    }
+    local = {
+      source = "hashicorp/local"
+    }
+  }
+}
+
+resource "tls_private_key" "windows_api" {
+  algorithm = "RSA"
+  rsa_bits  = 4096
+}
+
+resource "local_file" "windows_api_private_key" {
+  filename          = var.private_key_output_path
+  sensitive_content = tls_private_key.windows_api.private_key_pem
+  file_permission   = "0600"
+}
+
+resource "aws_key_pair" "windows_api" {
+  key_name   = var.key_pair_name
+  public_key = tls_private_key.windows_api.public_key_openssh
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.project_name}-windows-api-key"
+    }
+  )
+}
+
+resource "aws_security_group" "windows_api" {
+  name        = "${var.project_name}-windows-api-sg"
+  description = "Security group for Windows API instance"
+  vpc_id      = var.vpc_id
+
+  ingress {
+    description = "SSH access"
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    description = "HTTP access from VPC"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = var.http_ingress_cidrs
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.project_name}-windows-api-sg"
+    }
+  )
+}
+
+resource "aws_instance" "windows_api" {
+  ami                         = var.ami
+  instance_type               = var.instance_type
+  subnet_id                   = var.public_subnet_id
+  vpc_security_group_ids      = [aws_security_group.windows_api.id]
+  associate_public_ip_address = true
+  key_name                    = aws_key_pair.windows_api.key_name
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.project_name}-windows-api"
+    }
+  )
+}
+
+

--- a/modules/ec2/outputs.tf
+++ b/modules/ec2/outputs.tf
@@ -1,0 +1,31 @@
+output "instance_id" {
+  description = "ID of the Windows API instance"
+  value       = aws_instance.windows_api.id
+}
+
+output "public_ip" {
+  description = "Public IP of the Windows API instance"
+  value       = aws_instance.windows_api.public_ip
+}
+
+output "private_ip" {
+  description = "Private IP of the Windows API instance"
+  value       = aws_instance.windows_api.private_ip
+}
+
+output "security_group_id" {
+  description = "Security group ID for the Windows API instance"
+  value       = aws_security_group.windows_api.id
+}
+
+output "key_pair_name" {
+  description = "Name of the generated key pair"
+  value       = aws_key_pair.windows_api.key_name
+}
+
+output "private_key_path" {
+  description = "Path to the generated private key file"
+  value       = local_file.windows_api_private_key.filename
+}
+
+

--- a/modules/ec2/userdata.ps1.tpl
+++ b/modules/ec2/userdata.ps1.tpl
@@ -52,5 +52,7 @@ if (-not (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction Silentl
   New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH SSH Server (TCP)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
 }
 Set-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -Profile Domain,Private,Public -Enabled True
+
+New-NetFirewallRule -DisplayName 'Windows API 5085' -Direction Inbound -Protocol TCP -LocalPort 5085 -Action Allow
 </powershell>
 

--- a/modules/ec2/userdata.ps1.tpl
+++ b/modules/ec2/userdata.ps1.tpl
@@ -1,0 +1,56 @@
+<powershell>
+$ErrorActionPreference = "Stop"
+
+# Espera a que principalmente los servicios de red estén activos
+Start-Sleep -Seconds 30
+
+function Ensure-OpenSSHInstalled {
+  $feature = Get-WindowsCapability -Online | Where-Object { $_.Name -ilike 'OpenSSH.Server*' }
+  if ($null -eq $feature -or $feature.State -ne 'Installed') {
+    Add-WindowsCapability -Online -Name 'OpenSSH.Server~~~~0.0.1.0'
+  }
+}
+
+Ensure-OpenSSHInstalled
+
+Start-Service sshd
+Set-Service -Name sshd -StartupType Automatic
+if (Get-Service -Name ssh-agent -ErrorAction SilentlyContinue) {
+  Set-Service -Name ssh-agent -StartupType Automatic
+  Start-Service ssh-agent
+}
+
+$authorizedKeysPath = 'C:\ProgramData\ssh\administrators_authorized_keys'
+New-Item -ItemType Directory -Path (Split-Path $authorizedKeysPath) -Force | Out-Null
+@"
+${authorized_keys}
+"@ | Out-File -FilePath $authorizedKeysPath -Encoding ascii -Force
+
+& icacls $authorizedKeysPath /inheritance:r | Out-Null
+& icacls $authorizedKeysPath /grant 'SYSTEM:(F)' | Out-Null
+& icacls $authorizedKeysPath /grant 'Administrators:(F)' | Out-Null
+
+$configPath = 'C:\ProgramData\ssh\sshd_config'
+if (-not (Test-Path $configPath)) {
+  Copy-Item 'C:\Program Files\OpenSSH\sshd_config' $configPath -Force
+}
+
+$config = Get-Content $configPath
+if ($config -notcontains 'PubkeyAuthentication yes') {
+  Add-Content -Path $configPath -Value "PubkeyAuthentication yes"
+}
+if ($config -notcontains 'PasswordAuthentication no') {
+  Add-Content -Path $configPath -Value "PasswordAuthentication no"
+}
+if ($config -notcontains 'Subsystem sftp sftp-server.exe') {
+  Add-Content -Path $configPath -Value "Subsystem sftp sftp-server.exe"
+}
+
+Restart-Service sshd
+
+if (-not (Get-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -ErrorAction SilentlyContinue)) {
+  New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH SSH Server (TCP)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
+}
+Set-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -Profile Domain,Private,Public -Enabled True
+</powershell>
+

--- a/modules/ec2/variables.tf
+++ b/modules/ec2/variables.tf
@@ -49,4 +49,12 @@ variable "http_ingress_cidrs" {
   default     = ["10.0.0.0/16"]
 }
 
+variable "additional_ssh_public_keys" {
+  description = "Lista adicional de claves públicas SSH para autorizar en la instancia"
+  type        = list(string)
+  default     = []
+  nullable    = false
+  sensitive   = true
+}
+
 

--- a/modules/ec2/variables.tf
+++ b/modules/ec2/variables.tf
@@ -1,0 +1,52 @@
+variable "project_name" {
+  description = "Project name"
+  type        = string
+}
+
+variable "vpc_id" {
+  description = "ID of the VPC"
+  type        = string
+}
+
+variable "public_subnet_id" {
+  description = "ID of the public subnet where the instance will be deployed"
+  type        = string
+}
+
+variable "tags" {
+  description = "Common tags for all resources"
+  type        = map(string)
+  default     = {}
+}
+
+variable "instance_type" {
+  description = "Instance type for the Windows API EC2 instance"
+  type        = string
+  default     = "t3.medium"
+}
+
+variable "ami" {
+  description = "AMI ID for the Windows API EC2 instance"
+  type        = string
+  default     = "ami-07f134e32cbbbfc98"
+}
+
+variable "key_pair_name" {
+  description = "Name for the EC2 key pair"
+  type        = string
+  default     = "eks-terraform-windows-api"
+}
+
+variable "private_key_output_path" {
+  description = "Path where the generated private key will be stored"
+  type        = string
+  default     = "generated/windows-api-key.pem"
+}
+
+variable "http_ingress_cidrs" {
+  description = "List of CIDR blocks allowed to access the instance over HTTP"
+  type        = list(string)
+  default     = ["10.0.0.0/16"]
+}
+
+

--- a/modules/ecr/main.tf
+++ b/modules/ecr/main.tf
@@ -1,0 +1,32 @@
+resource "aws_ecr_repository" "frontend_dashboard" {
+  name                 = "frontend-dashboard"
+  image_tag_mutability = "IMMUTABLE"
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.project_name}-frontend-dashboard"
+    }
+  )
+}
+
+resource "aws_ecr_repository" "backend_ventas" {
+  name                 = "backend-ventas"
+  image_tag_mutability = "IMMUTABLE"
+
+  encryption_configuration {
+    encryption_type = "AES256"
+  }
+
+  tags = merge(
+    var.tags,
+    {
+      Name = "${var.project_name}-backend-ventas"
+    }
+  )
+}
+

--- a/modules/ecr/outputs.tf
+++ b/modules/ecr/outputs.tf
@@ -1,0 +1,10 @@
+output "frontend_dashboard_repository_url" {
+  description = "URL of the ECR repository for frontend-dashboard"
+  value       = aws_ecr_repository.frontend_dashboard.repository_url
+}
+
+output "backend_ventas_repository_url" {
+  description = "URL of the ECR repository for backend-ventas"
+  value       = aws_ecr_repository.backend_ventas.repository_url
+}
+

--- a/modules/ecr/variables.tf
+++ b/modules/ecr/variables.tf
@@ -1,0 +1,11 @@
+variable "project_name" {
+  description = "Name of the project"
+  type        = string
+}
+
+variable "tags" {
+  description = "Common tags for all resources"
+  type        = map(string)
+  default     = {}
+}
+

--- a/modules/eks-node-group/main.tf
+++ b/modules/eks-node-group/main.tf
@@ -1,25 +1,25 @@
-resource "aws_eks_node_group" "arm64" {
-  cluster_name = var.cluster_name
-  node_group_name = "${var.project_name}-node-group"
-  node_role_arn = var.node_role_arn
-  subnet_ids = var.private_subnet_ids
+# resource "aws_eks_node_group" "arm64" {
+#   cluster_name = var.cluster_name
+#   node_group_name = "${var.project_name}-node-group"
+#   node_role_arn = var.node_role_arn
+#   subnet_ids = var.private_subnet_ids
 
-  scaling_config {
-    desired_size = 2
-    min_size = 2
-    max_size = 3
-  }
+#   scaling_config {
+#     desired_size = 2
+#     min_size = 2
+#     max_size = 3
+#   }
 
-  ami_type = "AL2_ARM_64" # Amazon Linux 2 ARM
-  instance_types = ["t4g.medium"]
-  disk_size = 20
+#   ami_type = "AL2_ARM_64" # Amazon Linux 2 ARM
+#   instance_types = ["t4g.medium"]
+#   disk_size = 20
 
-  tags = var.tags
+#   tags = var.tags
 
-  depends_on = [
-    var.cluster_depends_on
-  ]
-}
+#   depends_on = [
+#     var.cluster_depends_on
+#   ]
+# }
 
 resource "aws_eks_node_group" "amd64" {
   cluster_name = var.cluster_name

--- a/modules/eks/main.tf
+++ b/modules/eks/main.tf
@@ -5,7 +5,7 @@ resource "aws_eks_cluster" "main" {
 
   vpc_config {
     subnet_ids = var.private_subnet_ids
-    endpoint_private_access = true
+    endpoint_private_access = false
     endpoint_public_access = true
     security_group_ids = [aws_security_group.cluster.id]
   }

--- a/modules/k8s-windows-api/main.tf
+++ b/modules/k8s-windows-api/main.tf
@@ -1,0 +1,96 @@
+locals {
+  common_labels = merge(
+    {
+      "app.kubernetes.io/part-of" = var.project_name
+      "app.kubernetes.io/managed-by" = "terraform"
+    },
+    var.labels
+  )
+}
+
+resource "kubernetes_service_v1" "windows_api" {
+  metadata {
+    name      = var.service_name
+    namespace = var.namespace
+    labels = merge(
+      local.common_labels,
+      {
+        "app.kubernetes.io/name" = var.service_name
+      }
+    )
+  }
+
+  spec {
+    port {
+      name        = "http"
+      port        = var.service_port
+      target_port = var.service_port
+      protocol    = "TCP"
+    }
+
+    type = "ClusterIP"
+  }
+}
+
+resource "kubernetes_endpoints_v1" "windows_api" {
+  metadata {
+    name      = kubernetes_service_v1.windows_api.metadata[0].name
+    namespace = kubernetes_service_v1.windows_api.metadata[0].namespace
+    labels    = kubernetes_service_v1.windows_api.metadata[0].labels
+  }
+
+  subset {
+    dynamic "address" {
+      for_each = var.endpoint_ips
+      content {
+        ip = address.value
+      }
+    }
+
+    port {
+      name     = "http"
+      port     = var.service_port
+      protocol = "TCP"
+    }
+  }
+}
+
+resource "kubernetes_ingress_v1" "windows_api" {
+  metadata {
+    name      = var.ingress_name
+    namespace = var.namespace
+    labels = merge(
+      local.common_labels,
+      {
+        "app.kubernetes.io/name" = var.ingress_name
+      }
+    )
+    annotations = var.ingress_annotations
+  }
+
+  spec {
+    ingress_class_name = var.ingress_class_name
+
+    rule {
+      http {
+        path {
+          path      = var.path
+          path_type = var.path_type
+
+          backend {
+            service {
+              name = kubernetes_service_v1.windows_api.metadata[0].name
+
+              port {
+                number = var.service_port
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [kubernetes_endpoints_v1.windows_api]
+}
+

--- a/modules/k8s-windows-api/outputs.tf
+++ b/modules/k8s-windows-api/outputs.tf
@@ -1,0 +1,16 @@
+output "service_name" {
+  description = "Name of the Kubernetes service"
+  value       = kubernetes_service_v1.windows_api.metadata[0].name
+}
+
+output "ingress_name" {
+  description = "Name of the Kubernetes ingress"
+  value       = kubernetes_ingress_v1.windows_api.metadata[0].name
+}
+
+output "namespace" {
+  description = "Namespace where resources were created"
+  value       = kubernetes_service_v1.windows_api.metadata[0].namespace
+}
+
+

--- a/modules/k8s-windows-api/variables.tf
+++ b/modules/k8s-windows-api/variables.tf
@@ -1,0 +1,65 @@
+variable "project_name" {
+  description = "Project name used for labeling"
+  type        = string
+}
+
+variable "namespace" {
+  description = "Namespace where Kubernetes resources will be created"
+  type        = string
+  default     = "default"
+}
+
+variable "service_name" {
+  description = "Name of the Kubernetes service"
+  type        = string
+  default     = "windows-api-service"
+}
+
+variable "ingress_name" {
+  description = "Name of the Kubernetes ingress"
+  type        = string
+  default     = "windows-api-ingress"
+}
+
+variable "service_port" {
+  description = "Service port"
+  type        = number
+  default     = 80
+}
+
+variable "endpoint_ips" {
+  description = "List of endpoint IPs for the service"
+  type        = list(string)
+}
+
+variable "path" {
+  description = "Path to route in the ingress"
+  type        = string
+  default     = "/api/inventario/"
+}
+
+variable "path_type" {
+  description = "Path type for the ingress"
+  type        = string
+  default     = "Prefix"
+}
+
+variable "ingress_class_name" {
+  description = "Ingress class name"
+  type        = string
+  default     = "nginx"
+}
+
+variable "labels" {
+  description = "Additional labels to apply"
+  type        = map(string)
+  default     = {}
+}
+
+variable "ingress_annotations" {
+  description = "Additional annotations for ingress"
+  type        = map(string)
+  default     = {}
+}
+
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -47,3 +47,18 @@ output "windows_api_private_key_path" {
   description = "Path to the generated private key for the Windows API EC2 instance"
   value       = module.ec2.private_key_path
 }
+
+output "windows_api_service_name" {
+  description = "Kubernetes service name for the Windows API"
+  value       = module.k8s_windows_api.service_name
+}
+
+output "windows_api_ingress_name" {
+  description = "Kubernetes ingress name for the Windows API"
+  value       = module.k8s_windows_api.ingress_name
+}
+
+output "windows_api_namespace" {
+  description = "Namespace where the Windows API Kubernetes resources were created"
+  value       = module.k8s_windows_api.namespace
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,13 @@ output "nat_gateway_eip" {
   description = "Elastic IP assigned to the NAT Gateway"
   value       = module.gateways.nat_gateway_eip
 }
+
+output "frontend_dashboard_repository_url" {
+  description = "URL of the ECR repository for frontend-dashboard"
+  value       = module.ecr.frontend_dashboard_repository_url
+}
+
+output "backend_ventas_repository_url" {
+  description = "URL of the ECR repository for backend-ventas"
+  value       = module.ecr.backend_ventas_repository_url
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -27,3 +27,23 @@ output "backend_ventas_repository_url" {
   description = "URL of the ECR repository for backend-ventas"
   value       = module.ecr.backend_ventas_repository_url
 }
+
+output "windows_api_instance_id" {
+  description = "ID of the Windows API EC2 instance"
+  value       = module.ec2.instance_id
+}
+
+output "windows_api_public_ip" {
+  description = "Public IP address of the Windows API EC2 instance"
+  value       = module.ec2.public_ip
+}
+
+output "windows_api_security_group_id" {
+  description = "Security group ID of the Windows API EC2 instance"
+  value       = module.ec2.security_group_id
+}
+
+output "windows_api_private_key_path" {
+  description = "Path to the generated private key for the Windows API EC2 instance"
+  value       = module.ec2.private_key_path
+}


### PR DESCRIPTION
- Añade módulos de infraestructura para repositorios ECR dedicados a `frontend-dashboard` y `backend-ventas`, gestionando cifrado AES256 y exponiendo las URLs como outputs reutilizables. 

- Incorpora un módulo `ec2` que genera un par de llaves TLS, persiste la clave privada localmente y levanta una instancia Windows con reglas de seguridad para SSH, RDP y el puerto 5085, incluyendo `userdata` que habilita OpenSSH y abre firewall.

- Define el módulo `k8s-windows-api` para orquestar un `Service`, `Endpoints` dinámicos y un `Ingress` que enruta `/api/inventario/` hacia la instancia Windows a través de NGINX, permitiendo configurar anotaciones y `IngressClass`.

- Extiende `main.tf` conectando los nuevos módulos con la red existente: utiliza el CIDR de la VPC para tráfico HTTP, consume la IP privada de la instancia en el Endpoints y alinea dependencias entre EKS, node group, addons y la capa de Windows.

- Despliega complementos para EKS: crea el proveedor OIDC, IAM role/policy del AWS Load Balancer Controller y publica dos `helm_release` (ALB controller y nginx-ingress), además de un Ingress adicional `nginx-ingress-alb` que expone el controlador vía ALB.

- Ajusta el módulo de node group para usar instancias `t3.medium` x86_64 con etiquetas `kubernetes.io/arch=amd64`, asegurando compatibilidad con cargas Windows y la cadena de ingress recién definida.